### PR TITLE
Fix Hiro Challenges tests fixture causing false positive test results

### DIFF
--- a/UnityHiroChallenges/Assets/UnityHiroChallenges/Tests/Editor/ChallengesIntegrationTests.cs
+++ b/UnityHiroChallenges/Assets/UnityHiroChallenges/Tests/Editor/ChallengesIntegrationTests.cs
@@ -69,6 +69,7 @@ namespace HiroChallenges.Tests.Editor
         [TearDown]
         public async Task TearDown()
         {
+            _controller.Dispose();
             await _client.DeleteAccountAsync(_session);
             await _client.DeleteAccountAsync(_inviteeSession);
         }
@@ -214,6 +215,7 @@ namespace HiroChallenges.Tests.Editor
         [TearDown]
         public async Task TearDown()
         {
+            _controller.Dispose();
             await _client.DeleteAccountAsync(_session);
         }
 
@@ -363,6 +365,8 @@ namespace HiroChallenges.Tests.Editor
         [TearDown]
         public async Task TearDown()
         {
+            _controller.Dispose();
+
             // Delete all test accounts
             for (var i = 0; i < 4; i++)
             {


### PR DESCRIPTION
Two integration tests were failing in Hiro Challenges. 
<img width="1521" height="927" alt="Screenshot 2026-05-25 at 13 27 09" src="https://github.com/user-attachments/assets/f3653b46-aa66-459d-94cd-d44b3a4f97ed" />

`ChallengesController` subscribes to `AccountSwitcher.AccountSwitched` in its constructor but implements `IDisposable` to unsubscribe. Their `TearDown` deleted the Nakama accounts from the server but never disposed the controller, leaving the subscriptions active. 

Tested against local server with Unity in edit mode. Test results xml shows all tests passing. 
<img width="1761" height="136" alt="Screenshot 2026-05-25 at 13 26 36" src="https://github.com/user-attachments/assets/84b43733-8d73-4e21-acdc-3c270ccfddf0" />
